### PR TITLE
add multiple pypi backend

### DIFF
--- a/collective/eggproxy/tests/test_utils.py
+++ b/collective/eggproxy/tests/test_utils.py
@@ -17,7 +17,7 @@ def test_index():
     page = open(os.path.join(tempdir, 'index.html')).read()
 
     # check case
-    assert 'PasteDeploy' in page
+    assert 'auth' in page
 
 @with_setup(setup_func, teardown_func)
 def test_local_index():
@@ -27,7 +27,8 @@ def test_local_index():
     index.updateBaseIndex(tempdir)
 
     page = open(os.path.join(tempdir, 'index.html')).read()
-    assert '<a href="my.eggproxy.test.package/">my.eggproxy.test.package</a>' in page
+    print page
+    assert '<a href="auth/">auth</a>' in page
 
 @with_setup(setup_func, teardown_func)
 def test_package():

--- a/collective/eggproxy/wsgi.py
+++ b/collective/eggproxy/wsgi.py
@@ -48,7 +48,7 @@ class EggProxyApp(object):
         if not os.path.isdir(eggs_dir):
             print 'You must create the %r directory' % eggs_dir
             sys.exit()
-        self.eggs_index_proxy = IndexProxy(PackageIndex(index_url=index_url))
+        self.eggs_index_proxy = IndexProxy(PackageIndex(index_url=index_url.split()))
         self.eggs_dir = eggs_dir
 
     def __call__(self, environ, start_response):


### PR DESCRIPTION
# add multiple pypi backend
## collective/eggproxy/tests/test_utils.py

I patched collective/eggproxy/tests/test_utils.py for another egg (the test don't use http://pypi.python.org/simple/ and I don't get it).
## collective/eggproxy/wsgi.py

I patched collective/eggproxy/wsgi.py for split for permit multi index definition :

::

  index =
      http://mypypi:8000/simple/
      http://pypi.python.org/simple
## collective/eggproxy/utils.py

I patched for use multiple index. I redifined several functions from setuptool.
